### PR TITLE
Add extern keyword to make it compile

### DIFF
--- a/rle.h
+++ b/rle.h
@@ -30,7 +30,7 @@ extern "C" {
  *** 43+3 codec ***
  ******************/
 
-const uint8_t rle_auxtab[8];
+extern const uint8_t rle_auxtab[8];
 
 #define RLE_MIN_SPACE 18
 #define rle_nptr(block) ((uint16_t*)(block))


### PR DESCRIPTION
Compilation was failing with the error 
``` multiple definition of `rle_auxtab'```

I added the `extern` keyword to the definition of `rle_auxtab` in the .h file so that it only gets defined once